### PR TITLE
Feature/challenge cleanup

### DIFF
--- a/Api/Migrations/20220727012529_duration.cs
+++ b/Api/Migrations/20220727012529_duration.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    public partial class duration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Duration",
+                table: "ChallengeReports",
+                type: "longtext",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double")
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<double>(
+                name: "Duration",
+                table: "ChallengeReports",
+                type: "double",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/Api/Migrations/20220727013449_duration2.cs
+++ b/Api/Migrations/20220727013449_duration2.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    public partial class duration2 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Duration",
+                table: "TestResults",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(double),
+                oldType: "double",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<double>(
+                name: "Duration",
+                table: "TestResults",
+                type: "double",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/Api/Migrations/SocialDbContextModelSnapshot.cs
+++ b/Api/Migrations/SocialDbContextModelSnapshot.cs
@@ -51,8 +51,9 @@ namespace Api.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    b.Property<double>("Duration")
-                        .HasColumnType("double");
+                    b.Property<string>("Duration")
+                        .IsRequired()
+                        .HasColumnType("longtext");
 
                     b.Property<int>("Points")
                         .HasColumnType("int");

--- a/Api/Migrations/SocialDbContextModelSnapshot.cs
+++ b/Api/Migrations/SocialDbContextModelSnapshot.cs
@@ -155,8 +155,8 @@ namespace Api.Migrations
                     b.Property<string>("AssertionMessage")
                         .HasColumnType("longtext");
 
-                    b.Property<double?>("Duration")
-                        .HasColumnType("double");
+                    b.Property<string>("Duration")
+                        .HasColumnType("longtext");
 
                     b.Property<string>("IncomingValues")
                         .HasColumnType("longtext");

--- a/ChallengeAssistant/ChallengeAssistant.csproj
+++ b/ChallengeAssistant/ChallengeAssistant.csproj
@@ -35,4 +35,9 @@
       </None>
     </ItemGroup>
 
+    <ItemGroup>
+      <Compile Remove="Grpc\ChallengerServiceImpl.cs" />
+      <Compile Remove="Contracts\ChallengeService.cs" />
+    </ItemGroup>
+
 </Project>

--- a/ChallengeAssistant/Commands/ChallengeCommands.cs
+++ b/ChallengeAssistant/Commands/ChallengeCommands.cs
@@ -1,9 +1,11 @@
-﻿using System.Text;
+﻿using System.Net;
+using System.Text;
+using ChallengeAssistant.Commands.AutoComplete;
 using ChallengeAssistant.Services;
+using Data.Challenges;
 using Discord;
 using Discord.Interactions;
 using DiscordHub;
-using Razor.Templating.Core;
 
 namespace ChallengeAssistant.Commands;
 
@@ -22,6 +24,54 @@ public class ChallengeCommands : InteractionModuleBase<SocketInteractionContext>
     }
 
     [RequireUserPermission(GuildPermission.Administrator)]
+    [SlashCommand("update-attempts", "update a user's number of attempts")]
+    public async Task UpdateUserAttempts(ProgrammingLanguage language, 
+        IUser user, 
+        int reduceAttemptsBy, 
+        [Autocomplete(typeof(ProgrammingChallengeAutoCompleteProvider))] string title)
+    {
+        _logger.LogInformation("{User} is attempting to update {OtherUser}'s number of attempts for {Challenge} by {Number}",
+            Context.User.Username,
+            user.Username,
+            title,
+            reduceAttemptsBy
+            );
+        
+        var response = await _service.ReduceUserAttemptsBy(user.Id.ToString(),
+            Math.Abs(reduceAttemptsBy),
+            title,
+            language);
+
+        var embed = new EmbedBuilder()
+            .WithTitle("Challenge Helper");
+
+        switch (response)
+        {
+            case HttpStatusCode.OK:
+                await RespondAsync(ephemeral: true,
+                    embed: embed.WithDescription("Successfully updated attempts for " + Context.User.Username)
+                        .WithColor(Color.Green)
+                        .WithFooter(response.ToString()).Build());
+                break;
+            case HttpStatusCode.BadRequest:
+                await RespondAsync(ephemeral: true,
+                    embed: embed
+                        .WithDescription(
+                            "Error locating things... are you sure this user submitted something for that?")
+                        .WithColor(Color.Red)
+                        .WithFooter(response.ToString()).Build());
+                break;
+            default:
+                await RespondAsync(ephemeral: true,
+                    embed: embed.WithDescription("Yeah IDK")
+                        .WithFooter(response.ToString())
+                        .WithColor(Color.Purple)
+                        .Build());
+                break;
+        }
+    }
+        
+    [RequireUserPermission(GuildPermission.Administrator)]
     [SlashCommand("generate", "create interactable challenges")]
     public async Task GenerateInChannel()
     {
@@ -33,16 +83,20 @@ public class ChallengeCommands : InteractionModuleBase<SocketInteractionContext>
             await Task.Delay(TimeSpan.FromSeconds(2));
         }
 
+        var comps = new ComponentBuilder().WithButton(new ButtonBuilder()
+            .WithStyle(ButtonStyle.Link)
+            .WithUrl("https://programming-simplified-community.github.io/Challenger/")
+            .WithLabel("Website"));
+        
         await Context.Channel.SendMessageAsync(embed: new EmbedBuilder()
             .WithTitle("Instructions")
-            .WithDescription("Due to character limitations on Discord, challenge information is now distributed through these HTML files!\n\n" +
-                             "Please note... that apparently your browser may directly open them without downloading. I suspect this has to do with their content delivery system?\n\n" +
-                             "Otherwise, download the HTML file and open with your favorite browser!\n\n" +
+            .WithDescription("Due to character limitations on Discord, challenge information is hosted on github pages!\n\n" +
                              "The leaderboard is ranked by #points, then by #attempts, then by duration")
             .WithColor(Color.Orange)
             .WithImageUrl("https://images.unsplash.com/photo-1605379399642-870262d3d051?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1806&q=80")
             .WithThumbnailUrl("https://img.freepik.com/free-vector/laptop-with-program-code-isometric-icon-software-development-programming-applications-dark-neon_39422-971.jpg?w=1380&t=st=1658011057~exp=1658011657~hmac=5168ecbad8636d17080e01d76bad5863e488966221d0e3dee7d4b21e9b45b868")
-            .Build());
+            .Build(),
+            components: comps.Build());
         
         var challenges = (await _service.GetAll())
             .OrderBy(x=>x.Title);
@@ -128,6 +182,37 @@ public class ChallengeCommands : InteractionModuleBase<SocketInteractionContext>
         catch (Exception ex)
         {
             _logger.LogError("Error occurred while fetching leaderboard: {Exception}", ex);
+        }
+    }
+
+    [RequireUserPermission(GuildPermission.Administrator)]
+    [SlashCommand("rerun-submission", "rerun a user's submission")]
+    public async Task RerunUserSubmission(IUser user,
+        [Autocomplete(typeof(ProgrammingChallengeAutoCompleteProvider))]
+        string title,
+        ProgrammingLanguage language)
+    {
+        var response = await _service.RerunUserSubmission(user.Id.ToString(),
+            title,
+            language);
+        
+        var embed = new EmbedBuilder()
+            .WithTitle("Challenge Assistant")
+            .WithFooter(response.ToString());
+
+        switch (response)
+        {
+            case HttpStatusCode.OK:
+                await RespondAsync(ephemeral: true,
+                    embed: embed.WithDescription("User's challenge is queued")
+                        .WithColor(Color.Green)
+                        .Build());
+                break;
+            default:
+                await RespondAsync(ephemeral: true,
+                    embed: embed.WithDescription("Something went wrong")
+                        .WithColor(Color.Red).Build());
+                break;
         }
     }
 }

--- a/ChallengeAssistant/DockerTypes/PythonDockerTest.cs
+++ b/ChallengeAssistant/DockerTypes/PythonDockerTest.cs
@@ -1,4 +1,5 @@
-﻿using ChallengeAssistant.Reports;
+﻿using System.Globalization;
+using ChallengeAssistant.Reports;
 using Core.Storage;
 using Data.Challenges;
 using Newtonsoft.Json.Linq;
@@ -69,7 +70,8 @@ public class PythonDockerTest : DockerTest
         
         var report = new ProgrammingChallengeReport
         {
-            ProgrammingChallengeId = Test.ProgrammingChallengeId
+            ProgrammingChallengeId = Test.ProgrammingChallengeId,
+            Duration = results.Duration.ToString()
         };
 
         foreach (var test in results.Tests)
@@ -79,7 +81,7 @@ public class PythonDockerTest : DockerTest
                 Name = test.TestName,
                 ProgrammingChallengeReportId = Test.ProgrammingChallengeId,
                 Result = test.Outcome == PytestOutcome.Passed ? TestStatus.Pass : TestStatus.Fail,
-                Duration = test.CallDuration,
+                Duration = test.CallDuration.ToString(CultureInfo.InvariantCulture),
                 AssertionMessage = test.AssertionMessage,
                 IncomingValues = test.IncomingValues,
                 TotalFails = test.Failed,
@@ -115,7 +117,8 @@ public class PythonDockerTest : DockerTest
 
         var report = new ProgrammingChallengeReport
         {
-            ProgrammingChallengeId = challengeId
+            ProgrammingChallengeId = challengeId,
+            Duration = pytestReport.Duration.ToString(CultureInfo.InvariantCulture)
         };
 
         foreach (var test in pytestReport.Tests)
@@ -125,7 +128,7 @@ public class PythonDockerTest : DockerTest
                 Name = test.TestName,
                 ProgrammingChallengeReportId = challengeId,
                 Result = test.Outcome == PytestOutcome.Passed ? TestStatus.Pass : TestStatus.Fail,
-                Duration = test.CallDuration,
+                Duration = test.CallDuration.ToString(CultureInfo.InvariantCulture),
                 AssertionMessage = test.AssertionMessage,
                 IncomingValues = test.IncomingValues,
                 TotalFails = test.Failed,
@@ -222,7 +225,8 @@ public class PythonDockerTest : DockerTest
                     Failed = container.Failed,
                     Total = container.Total
                 });
-            
+
+            report.Duration = (decimal) report.Tests.Sum(x => x.CallDuration);
             return Task.FromResult<PytestReport?>(report);
         }
         catch (Exception ex)

--- a/ChallengeAssistant/Requests/SubmitProgrammingChallengeRequest.cs
+++ b/ChallengeAssistant/Requests/SubmitProgrammingChallengeRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Data.Challenges;
 
 namespace ChallengeAssistant.Requests;
 
@@ -29,4 +30,6 @@ public class SubmitProgrammingChallengeRequest
     /// </summary>
     [Required]
     public string Code { get; set; }
+
+    public ProgrammingLanguage Language { get; set; } = ProgrammingLanguage.Python;
 }

--- a/ChallengeAssistant/Services/ChallengeService.cs
+++ b/ChallengeAssistant/Services/ChallengeService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
+using ChallengeAssistant.Models;
 using ChallengeAssistant.Requests;
 using Core.Validation;
-using Data;
 using Data.Challenges;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
@@ -21,11 +21,79 @@ public class ChallengeService
 {
     private readonly ILogger<ChallengeService> _logger;
     private readonly SocialDbContext _context;
+    private readonly IServiceProvider _serviceProvider;
     
-    public ChallengeService(ILogger<ChallengeService> logger, SocialDbContext context)
+    public ChallengeService(ILogger<ChallengeService> logger, SocialDbContext context, IServiceProvider serviceProvider)
     {
         _logger = logger;
         _context = context;
+        _serviceProvider = serviceProvider;
+    }
+    
+    /// <summary>
+    /// Attempt to rerun a user's submission without having the user required to resubmit their code. Also doesn't impact their number of attempts
+    /// because this is done by an administrator, not the user
+    /// </summary>
+    /// <param name="discordId">ID of the user whose submission we want to rerun</param>
+    /// <param name="challengeTitle">Title of challenge we want to search by</param>
+    /// <param name="language">The language in which the user submitted for</param>
+    /// <returns>StatusCode indicating level of success</returns>
+    public async Task<HttpStatusCode> RerunUserSubmission(string discordId, string challengeTitle, ProgrammingLanguage language)
+    {
+        var user = await _context.Users.FirstOrDefaultAsync(x => x.DiscordUserId == discordId);
+
+        if (user is null)
+            return HttpStatusCode.NotFound;
+
+        var challenge = await _context.ProgrammingChallenges.FirstOrDefaultAsync(x => x.Title == challengeTitle);
+
+        if (challenge is null)
+            return HttpStatusCode.NotFound;
+
+        var submission = await _context.ProgrammingChallengeSubmissions.FirstOrDefaultAsync(x => x.UserId == user.Id &&
+            x.ProgrammingChallengeId == challenge.Id &&
+            x.SubmittedLanguage == language);
+
+        if (submission is null)
+            return HttpStatusCode.NotFound;
+        
+        var runner = _serviceProvider.GetRequiredService<ICodeRunner>();
+        UserSubmissionQueueItem item = new(challenge.Tests.First(x=>x.Language == language), submission, submission.UserSubmission);
+        await runner.Enqueue(item);
+        return HttpStatusCode.OK;
+    }
+    
+    /// <summary>
+    /// Reduce a user's number of attempts by <paramref name="reduceBy"/> amount
+    /// </summary>
+    /// <param name="discordUserId">User who we want to help out</param>
+    /// <param name="reduceBy">Amount in which we want to reduce by</param>
+    /// <param name="challengeTitle">Title in which we are reducing attempts for</param>
+    /// <param name="language">Filters the submission by language (can have multiple language attempts...)</param>
+    /// <returns></returns>
+    public async Task<HttpStatusCode> ReduceUserAttemptsBy(string discordUserId, int reduceBy, string challengeTitle, ProgrammingLanguage language)
+    {
+        var challenge = await _context.ProgrammingChallenges.FirstOrDefaultAsync(x => x.Title == challengeTitle);
+
+        if (challenge is null)
+            return HttpStatusCode.BadRequest;
+        
+        var user = await _context.Users.FirstOrDefaultAsync(x => x.DiscordUserId == discordUserId);
+
+        if (user is null)
+            return HttpStatusCode.BadRequest;
+
+        var submission = await _context.ProgrammingChallengeSubmissions.FirstOrDefaultAsync(x => x.UserId == user.Id &&
+            x.ProgrammingChallengeId == challenge.Id &&
+            x.SubmittedLanguage == language);
+
+        if (submission is null)
+            return HttpStatusCode.NotFound;
+
+        submission.Attempt -= Math.Max(submission.Attempt - reduceBy, 0);
+        await _context.SaveChangesAsync();
+
+        return HttpStatusCode.OK;
     }
 
     /// <summary>
@@ -56,7 +124,7 @@ public class ChallengeService
                 new LeaderboardEntry(x.Key, 
                     submissions[x.First().UserId], 
                     x.Sum(y => y.Points),
-                    x.Sum(y => y.Duration))
+                    x.Sum(y => double.Parse(y.Duration)))
             )
             .OrderByDescending(x => x.Points)
             .ThenBy(x=>x.Attempts)
@@ -139,74 +207,67 @@ public class ChallengeService
     /// </summary>
     /// <param name="request"></param>
     /// <returns></returns>
-    public async Task<ResultOf<HttpStatusCode>> Submit(SubmitProgrammingChallengeRequest request)
+    public async Task<ResultOf<int>> Submit(SubmitProgrammingChallengeRequest request)
     {
-        #region Validation
-
-        var validationResult = Validator.Validate(request);
-
-        if (!validationResult.IsValid)
+        try
         {
-            var errors = string.Join(Environment.NewLine, validationResult.Errors);
-            _logger.LogWarning("Invalid data was provided to {Name}: {Errors}", nameof(Submit), errors);
-            return ResultOf<HttpStatusCode>.Error(errors);
-        }
+            var runner = _serviceProvider.GetRequiredService<ICodeRunner>();
+            
+            // If the user does not already exist in our system we'll add them!
+            var user = await _context.GetOrAddUser(request.DiscordUsername, request.DiscordUserId);
 
-        var challengeItemTask =
-            _context.ProgrammingChallenges.FirstOrDefaultAsync(x => x.Id == request.ProgrammingChallengeId);
-        var userItemTask = _context.Users.FirstOrDefaultAsync(x => x.DiscordUserId == request.DiscordUserId);
-
-        await Task.WhenAll(challengeItemTask, userItemTask);
-        
-        if(challengeItemTask.Result is null)
-            return ResultOf<HttpStatusCode>.NotFound("Could not locate challenge");
-
-        ProgrammingChallengeSubmission? submission = null;
-
-        var userId = userItemTask.Result?.Id ?? string.Empty;
-        
-        if (userItemTask.Result is not null)
-        {
-            submission = await _context.ProgrammingChallengeSubmissions.FirstOrDefaultAsync(x =>
-                x.ProgrammingChallengeId == request.ProgrammingChallengeId && x.UserId == userItemTask.Result.Id);
-        }
-        else
-        {
-            var user = new SocialUser
+            var challenge = await _context.ProgrammingChallenges
+                .Include(x => x.Tests)
+                .FirstOrDefaultAsync(x => x.Id == request.ProgrammingChallengeId);
+            
+            // Ensure the challenge is one we actually have in store
+            if (challenge is null)
             {
-                DiscordUserId = request.DiscordUserId,
-                UserName = request.DiscordUsername,
-                NormalizedUserName = request.DiscordUsername.ToUpper(),
-                Email = "changeme@gmail.com",
-                DiscordDisplayName = request.DiscordUsername
-            };
+                _logger.LogError("Was unable to locate challenge with Id {Id} for user {Username}",
+                    request.ProgrammingChallengeId,
+                    request.DiscordUsername);
+                return ResultOf<int>.NotFound("Could not locate challenge");
+            }
 
-            _context.Users.Add(user);
+            var existingSubmission = await _context.ProgrammingChallengeSubmissions
+                .FirstOrDefaultAsync(x => x.UserId == user.Id && 
+                                          x.ProgrammingChallengeId == challenge.Id &&
+                                          x.SubmittedLanguage == request.Language);
+            
+            /*
+                We don't need a billion submission records for the SAME language + challenge for a user. 
+                Just update existing records when applicable to conserve DB space.
+             */
+            
+            if (existingSubmission is not null)
+            {
+                existingSubmission.UserSubmission = request.Code;
+                existingSubmission.Attempt++;
+                existingSubmission.SubmittedOn = DateTime.UtcNow;
+            }
+            else
+            {
+                existingSubmission =new ProgrammingChallengeSubmission
+                {
+                    UserSubmission = request.Code,
+                    SubmittedLanguage = request.Language,
+                    ProgrammingChallengeId = challenge.Id,
+                    UserId = user.Id
+                };
+                
+                _context.ProgrammingChallengeSubmissions.Add(existingSubmission);
+            }
+
             await _context.SaveChangesAsync();
-
-            userId = user.Id; // update our cached id
+            
+            UserSubmissionQueueItem item = new(challenge.Tests.First(x=>x.Language == request.Language), existingSubmission, request.Code);
+            await runner.Enqueue(item);
+            return ResultOf<int>.Success(runner.PendingSubmissions);
         }
-        
-        #endregion
-
-        if (submission is null)
+        catch (Exception ex)
         {
-            submission = new()
-            {
-                UserId = userId,
-                ProgrammingChallengeId = request.ProgrammingChallengeId,
-                UserSubmission = request.Code
-            };
-
-            _context.ProgrammingChallengeSubmissions.Add(submission);
+            _logger.LogError("Error occurred while processing Modal: {Exception}", ex);
+            return ResultOf<int>.Error("Something went wrong: " + ex.Message);
         }
-        else
-        {
-            submission.UserSubmission = request.Code;
-            submission.SubmittedOn = DateTime.UtcNow;
-        }            
-        
-        await _context.SaveChangesAsync();
-        return ResultOf<HttpStatusCode>.Success(HttpStatusCode.OK);
     }
 }

--- a/ChallengeAssistant/Services/CodeRunnerService.cs
+++ b/ChallengeAssistant/Services/CodeRunnerService.cs
@@ -97,6 +97,7 @@ public class CodeRunnerService : BackgroundService, ICodeRunner
                 if (existingReport is not null)
                 {
                     existingReport.Points = passing;
+                    existingReport.Duration = results.Duration ?? "0";
                     _context.TestResults.RemoveRange(existingReport.TestResults);
                     var testResults = results.TestResults;
                     _context.TestResults.AddRange(results.TestResults);

--- a/ChallengeAssistant/Services/InteractionHandlers/SubmitChallengeModalInteractionHandler.cs
+++ b/ChallengeAssistant/Services/InteractionHandlers/SubmitChallengeModalInteractionHandler.cs
@@ -5,7 +5,6 @@ using Data.Challenges;
 using Discord;
 using Discord.WebSocket;
 using DiscordHub;
-using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -18,98 +17,53 @@ namespace ChallengeAssistant.Services.InteractionHandlers;
 [DiscordInteractionHandlerName("Submit Challenge", Constants.CHALLENGE_MODAL_PREFIX)]
 public class SubmitChallengeModalInteractionHandler : IDiscordModalHandler
 {
-    private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<SubmitChallengeModalInteractionHandler> _logger;
-    private readonly SocialDbContext _context;
+    private readonly ChallengeService _service;
 
-    public SubmitChallengeModalInteractionHandler(IServiceProvider serviceProvider, ILogger<SubmitChallengeModalInteractionHandler> logger, SocialDbContext context)
+    public SubmitChallengeModalInteractionHandler(ILogger<SubmitChallengeModalInteractionHandler> logger, ChallengeService service)
     {
-        _serviceProvider = serviceProvider;
         _logger = logger;
-        _context = context;
+        _service = service;
     }
 
     public async Task<ResultOf<HttpStatusCode>> HandleModal(SocketModal modal)
     {
+        if (!modal.Data.CustomId.ExtractChallengeInfo(Constants.CHALLENGE_MODAL_PREFIX, out var challengeInfo))
+            return ResultOf<HttpStatusCode>.Success(HttpStatusCode.OK);
+        
+        var components = modal.Data.Components.ToList();
+
         try
         {
-            if (!modal.Data.CustomId.ExtractChallengeInfo(Constants.CHALLENGE_MODAL_PREFIX, out var challengeInfo))
-                return ResultOf<HttpStatusCode>.Success(HttpStatusCode.OK);
-            
-            var components = modal.Data.Components.ToList();
-            var runner = _serviceProvider.GetRequiredService<ICodeRunner>();
-            
-            // If the user does not already exist in our system we'll add them!
-            var user = await _context.GetOrAddUser(modal.User.Username, modal.User.Id.ToString());
-
-            var challenge = await _context.ProgrammingChallenges
-                .Include(x => x.Tests)
-                .FirstOrDefaultAsync(x => x.Id == challengeInfo!.Value.Id);
-            
-            // Ensure the challenge is one we actually have in store
-            if (challenge is null)
+            var response = await _service.Submit(new()
             {
-                _logger.LogError("Was unable to locate challenge with Id {Id} for user {Username}",
-                    challengeInfo!.Value.Id,
-                    modal.User.Username);
-                return ResultOf<HttpStatusCode>.Success(HttpStatusCode.OK);
-            }
-            
-            // For now we only have 1 component in there, the code.
-            var code = components.First(x => x.CustomId == "code").Value;
+                ProgrammingChallengeId = challengeInfo!.Value.Id,
+                Code = components.First(x => x.CustomId == "code").Value,
+                Language = challengeInfo.Value.Language,
+                DiscordUsername = modal.User.Username,
+                DiscordUserId = modal.User.Id.ToString()
+            });
 
-            var existingSubmission = await _context.ProgrammingChallengeSubmissions
-                .FirstOrDefaultAsync(x => x.UserId == user.Id && 
-                                          x.ProgrammingChallengeId == challengeInfo!.Value.Id &&
-                                          x.SubmittedLanguage == challengeInfo!.Value.Language);
+            if (response.StatusCode != HttpStatusCode.OK)
+                return new ResultOf<HttpStatusCode>(response.StatusCode, response.Message, response.StatusCode);
             
-            /*
-                We don't need a billion submission records for the SAME language + challenge for a user. 
-                Just update existing records when applicable to conserve DB space.
-             */
-            
-            if (existingSubmission is not null)
-            {
-                existingSubmission.UserSubmission = code;
-                existingSubmission.DiscordChannelId = modal.ChannelId?.ToString() ?? string.Empty;
-                existingSubmission.DiscordGuildId = modal.GuildId?.ToString() ?? string.Empty;
-                existingSubmission.Attempt++;
-            }
-            else
-            {
-                existingSubmission =new ProgrammingChallengeSubmission
-                {
-                    UserSubmission = code,
-                    SubmittedLanguage = challengeInfo!.Value.Language,
-                    ProgrammingChallengeId = challengeInfo!.Value.Id,
-                    DiscordGuildId = modal.GuildId?.ToString() ?? string.Empty,
-                    DiscordChannelId = modal.ChannelId?.ToString() ?? string.Empty,
-                    UserId = user.Id
-                };
-                
-                _context.ProgrammingChallengeSubmissions.Add(existingSubmission);
-            }
-
-            await _context.SaveChangesAsync();
-            
-            // Inform the user that their request is processing. Also letting them know how many others are waiting for their code to be tested
             var e = new EmbedBuilder()
                 .WithTitle("Processing Request")
-                .WithDescription($"There are: {runner.PendingSubmissions} submissions ahead of you.")
+                .WithDescription($"There are: {response.Result} submissions ahead of you.")
                 .WithColor(Discord.Color.Purple)
                 .WithFooter("Please be patient");
-            
+        
             await modal.RespondAsync(embed: e.Build(), ephemeral: true);
-            
-            UserSubmissionQueueItem item = new(challenge.Tests.First(x=>x.Language == challengeInfo!.Value.Language), existingSubmission, code);
-            await runner.Enqueue(item);
+            return ResultOf<HttpStatusCode>.Success(response.StatusCode);
+
         }
         catch (Exception ex)
         {
-            _logger.LogError("Error occurred while processing Modal: {Exception}", ex);
-            await modal.RespondAsync(ephemeral: true, text: "Error occurred while processing...");
+            _logger.LogError("An error occurred while processing submission request from {Username}:\n{Error}",
+                modal.User.Username,
+                ex);
+            
+            return ResultOf<HttpStatusCode>.Error(ex.Message);
         }
-        
-        return ResultOf<HttpStatusCode>.Success(HttpStatusCode.OK);
     }
 }

--- a/ChallengeAssistant/Views/Shared/Leaderboard.cshtml
+++ b/ChallengeAssistant/Views/Shared/Leaderboard.cshtml
@@ -40,16 +40,19 @@
                     <table class="table table-dark table-hover">
                         <thead>
                             <tr>
+                                <th>Rank</th>
                                 <th>Name</th>
                                 <th>Points</th>
                                 <th>Attempts</th>
-                                <th>Duration</th>                                    
+                                <th>Duration</th>
                             </tr>                                
                         </thead>
                         <tbody>
-                            @foreach (var entry in Model)
+                            @for(var i = 0; i < Model.Count; i++)
                             {
+                                var entry = Model[i];
                                 <tr>
+                                    <td>@(i+1).</td>
                                     <td>
                                         <span>
                                             @if (!string.IsNullOrEmpty(entry.Avatar))

--- a/ChallengeAssistant/Views/Shared/Leaderboard.cshtml
+++ b/ChallengeAssistant/Views/Shared/Leaderboard.cshtml
@@ -1,0 +1,77 @@
+﻿@model List<ChallengeAssistant.Services.LeaderboardEntry>
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Challengers Leaderboard</title>
+    <script src="https://kit.fontawesome.com/09b9c96735.js" crossorigin="anonymous"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/androidstudio.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js"></script>
+    <script>hljs.highlightAll();</script>
+    <style>
+            .avatar {
+                font-size: 16px;
+                width: 3em;
+                height: 3em;
+                border-radius: 50%;
+                background: #009578;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;       
+                vertical-align: middle;     
+            }
+    
+            .avatar::after{
+                content: attr(data-label);
+                font-family: "Readex Pro", sans-serif;
+                color: #ffffff;
+            }
+        </style>
+  </head>
+  <body class="bg-dark text-white">
+    <div class="container-fluid">
+        <div class="row">
+            <main class="col-12 px-md-4">
+                <h3 class="text-center mt-3">Leaderboard</h3>
+                <div class="d-flex justify-content-between flex-wrap flex-md align-items-center pt-3 pb-2 mb-3 mt-5">
+                    <table class="table table-dark table-hover">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Points</th>
+                                <th>Attempts</th>
+                                <th>Duration</th>                                    
+                            </tr>                                
+                        </thead>
+                        <tbody>
+                            @foreach (var entry in Model)
+                            {
+                                <tr>
+                                    <td>
+                                        <span>
+                                            @if (!string.IsNullOrEmpty(entry.Avatar))
+                                            {
+                                                <img class="avatar" src="@entry.Avatar"/>
+                                            }
+                                            @entry.Username
+                                        </span>
+                                    </td>
+                                    <td>@entry.Points</td>
+                                    <td>@entry.Attempts</td>
+                                    <td>@entry.Duration</td>
+                                </tr>    
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/Data/Challenges/ProgrammingTestResults.cs
+++ b/Data/Challenges/ProgrammingTestResults.cs
@@ -30,7 +30,7 @@ public class ProgrammingChallengeReport
     /// <summary>
     /// Total time it took to execute these tests
     /// </summary>
-    public double Duration { get; set; }
+    public string Duration { get; set; }
 
     /// <summary>
     /// Test results associated with this report

--- a/Data/Challenges/ProgrammingTestResults.cs
+++ b/Data/Challenges/ProgrammingTestResults.cs
@@ -52,7 +52,7 @@ public class ProgrammingTestResult
     /// </summary>
     public string Name { get; set; } = default!;
 
-    public double? Duration { get; set; }
+    public string? Duration { get; set; }
 
     /// <summary>
     /// Total number of runs for this method/test case


### PR DESCRIPTION
Quality of life changes have been implemented

# As an administrator
- Can rerun a user's submission for a specific challenge and language
- Can reduce number of attempts for a user on a specific challenge by a specified amount

# Misc
Leaderboard now uses the Razor Engine. 

# Bug Fixes
- Duration is now captured and stored properly in the database. This did require a migration, switching from double to string. String is the only way to preserve smaller numbers (otherwise it's rounded to 0).

# Cleanup
The ChallengeService class now contains most of the logic, removed logic from the discord command/modal interaction section.